### PR TITLE
Docker Build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.9 AS build-env
+
+WORKDIR /go/src/github.com/larsp/co2monitor
+
+COPY . ./
+
+RUN go-wrapper download
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build -v -ldflags "-w -s"  -a -installsuffix cgo -o /out/co2monitor
+
+FROM scratch
+COPY --from=build-env /out/co2monitor /
+ENTRYPOINT [ "./co2monitor" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
-FROM golang:1.9 AS build-env
+FROM golang:1.9.3-stretch AS build-env
+
+RUN go-wrapper download github.com/golang/dep/cmd/dep && go-wrapper install github.com/golang/dep/cmd/dep
 
 WORKDIR /go/src/github.com/larsp/co2monitor
 
+# only copy Gopkg.toml and Gopkg.lock for now so dep ensure run keeps cached till those files are changed
+COPY Gopkg.* ./
+RUN dep ensure -v --vendor-only
+
 COPY . ./
-
-RUN go-wrapper download
-
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build -v -ldflags "-w -s"  -a -installsuffix cgo -o /out/co2monitor
 
 FROM scratch

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ build:
 build_pi:
 	GOOS=linux GOARCH=arm GOARM=6 go build -v
 
+build_docker_pi:
+	docker build .
+
 test:
 	go test --race -v ./...
 


### PR DESCRIPTION
I just added a quick and dirty Dockerfile which creates a ~6MB docker container.

You can use `make build_docker_pi` to build the image on every distro supported by the official [golang image](https://hub.docker.com/r/library/golang/).


I haven't tagged the image yet, but after building the image it can be run with 
```
docker run --rm -it --device /dev/hidraw0 -p 8080:8080 <imagename> /dev/hidraw0
```

If you want I can also supply some travis build magic for pushing the image to the docker registry, add support for other architectures and write a docker-compose file for a quickstart with Grafana, Prometheus and that image.