### PR TITLE
Round temperature to one decimal place

### DIFF
--- a/meter/meter.go
+++ b/meter/meter.go
@@ -6,6 +6,7 @@ import (
 	"unsafe"
 
 	"log"
+	"math"
 
 	"crypto/rand"
 
@@ -96,7 +97,7 @@ func (m *Meter) Read() (*Measurement, error) {
 		case meterCO2:
 			measurement.Co2 = int(value)
 		case meterTemp:
-			measurement.Temperature = float64(value)/16.0 - 273.15
+			measurement.Temperature = math.Round((float64(value)/16.0 - 273.15) * 100.0) / 100.0
 		}
 
 		if measurement.Co2 != 0 && measurement.Temperature != -273.15 {


### PR DESCRIPTION
My CO2 monitor device returned temperature values like 22.537500000000023, which are of course completely useless in practice, since the device is not nearly as exact as that.

Generate nicer numbers by rounding to one decimal place.